### PR TITLE
removed service account definition from manifest

### DIFF
--- a/eks-image-discovery/config/eks-image-discovery.yaml
+++ b/eks-image-discovery/config/eks-image-discovery.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sbom-image-discovery
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,12 +8,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: image-discovery-job
-  namespace: sbom-image-discovery
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Service account and namespace will be created using eksctl which adds the correct IAM role annotation to the service account. SA and namespace resources have been removed from the cronjob manifest.