### PR TITLE
chore: Bump version of syft

### DIFF
--- a/terraform/build-spec/buildspec.yaml
+++ b/terraform/build-spec/buildspec.yaml
@@ -7,7 +7,7 @@ phases:
       - aws --version
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com
       - echo "Installing Syft..."
-      - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v0.85.0
+      - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.11.1
       - | 
         if $ECR_PUSH == "true"; then
           VERSION="1.0.0"

--- a/terraform/one-off-build-spec/buildspec.yaml
+++ b/terraform/one-off-build-spec/buildspec.yaml
@@ -6,7 +6,7 @@ phases:
       - echo "Logging in to Amazon ECR..."
       - aws --version
       - echo "Installing Syft..."
-      - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v0.85.0
+      - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.11.1
       - export ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
       - echo "Installing ORAS CLI"
       - | 


### PR DESCRIPTION
The version of syft used in the yamls is somewhat outdated now.

*Description of changes:*

This gets the latest syft, which at the time of writing is v1.11.1
